### PR TITLE
Add create server endpoint to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ $servers = $spinupwp->servers->list();
 // Return a single server
 $server = $spinupwp->servers->get($serverId);
 
+// Create and return a new server 
+$server = $spinupwp->servers->create([]);
+
 // Delete a server
 $eventId = $spinupwp->servers->delete($serverId, $deleteOnProvider);
 

--- a/src/Endpoints/Server.php
+++ b/src/Endpoints/Server.php
@@ -27,6 +27,25 @@ class Server extends Endpoint
         return new ServerResource($server, $this->spinupwp);
     }
 
+    public function create(array $data, bool $wait = false): ServerResource
+    {
+        $server = $this->postRequest('servers', $data);
+
+        if ($wait) {
+            return $this->wait(function () use ($server) {
+                $event = $this->spinupwp->events->get($server['event_id']);
+
+                if (!in_array($event->status, ['deployed', 'failed'])) {
+                    return false;
+                }
+
+                return $this->get($server['data']['id']);
+            });
+        }
+
+        return new ServerResource($server, $this->spinupwp);
+    }
+
     public function delete(int $id, bool $deleteOnProvider = false): int
     {
         $request = $this->deleteRequest("servers/{$id}", [

--- a/tests/Endpoints/ServerTest.php
+++ b/tests/Endpoints/ServerTest.php
@@ -43,6 +43,20 @@ class ServerTest extends TestCase
         $this->assertCount(2, $servers);
     }
 
+    public function test_create_request(): void
+    {
+        $this->client->shouldReceive('request')->once()->with('POST', 'servers', [
+            'form_params' => [
+                'hostname' => 'hellfish-media',
+            ],
+        ])->andReturn(
+            new Response(200, [], '{"data": {"name": "hellfish-media"}}')
+        );
+
+        $server = $this->serverEndpoint->create(['hostname' => 'hellfish-media']);
+        $this->assertEquals('hellfish-media', $server->name);
+    }
+
     public function test_delete_request(): void
     {
         $this->client->shouldReceive('request')->once()->with('DELETE', 'servers/1', [


### PR DESCRIPTION
This adds the create server endpoint from https://github.com/spinupwp/spinupwp/pull/2704 to the SDK.