### PR TITLE
Add support for ssh key and provision custom servers endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 /phpunit.xml
 .phpunit.result.cache
 .php-cs-fixer.cache
+.idea

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ $server = $spinupwp->servers->get($serverId);
 // Create and return a new server 
 $server = $spinupwp->servers->create([]);
 
+// Create and return a new custom server 
+$server = $spinupwp->servers->createCustom([]);
+
 // Delete a server
 $eventId = $spinupwp->servers->delete($serverId, $deleteOnProvider);
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ $events = $spinupwp->events->list();
 $event = $spinupwp->events->get($eventId);
 ```
 
+### SSH Key
+```php
+// Return SpinupWP's SSH Public Key
+$key = $spinupwp->sshKeys->get();
+```
+
 ### Resource Collections
 When retrieving a list of resources, an instance of `ResourceCollection` is returned. This class handles fetching large lists of resources without having to paginate results and perform subsequent requests manually.
 ```php

--- a/src/Endpoints/Server.php
+++ b/src/Endpoints/Server.php
@@ -29,21 +29,12 @@ class Server extends Endpoint
 
     public function create(array $data, bool $wait = false): ServerResource
     {
-        $server = $this->postRequest('servers', $data);
+        return $this->createServer('servers', $data, $wait);
+    }
 
-        if ($wait) {
-            return $this->wait(function () use ($server) {
-                $event = $this->spinupwp->events->get($server['event_id']);
-
-                if (!in_array($event->status, ['deployed', 'failed'])) {
-                    return false;
-                }
-
-                return $this->get($server['data']['id']);
-            });
-        }
-
-        return new ServerResource($server, $this->spinupwp);
+    public function createCustom(array $data, bool $wait = false): ServerResource
+    {
+        return $this->createServer('servers/custom', $data, $wait);
     }
 
     public function delete(int $id, bool $deleteOnProvider = false): int
@@ -81,5 +72,24 @@ class Server extends Endpoint
         $request = $this->postRequest("servers/{$id}/services/mysql/restart");
 
         return $request['event_id'];
+    }
+
+    private function createServer(string $endpoint, array $data, bool $wait = false): ServerResource
+    {
+        $server = $this->postRequest($endpoint, $data);
+
+        if ($wait) {
+            return $this->wait(function () use ($server) {
+                $event = $this->spinupwp->events->get($server['event_id']);
+
+                if (!in_array($event->status, ['deployed', 'failed'])) {
+                    return false;
+                }
+
+                return $this->get($server['data']['id']);
+            });
+        }
+
+        return new ServerResource($server, $this->spinupwp);
     }
 }

--- a/src/Endpoints/SshKey.php
+++ b/src/Endpoints/SshKey.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SpinupWp\Endpoints;
+
+class SshKey extends Endpoint
+{
+    public function get(): string
+    {
+        $response = $this->getRequest('ssh-key');
+
+        return $response['key'];
+    }
+}

--- a/src/SpinupWp.php
+++ b/src/SpinupWp.php
@@ -6,11 +6,13 @@ use GuzzleHttp\Client as HttpClient;
 use SpinupWp\Endpoints\Event;
 use SpinupWp\Endpoints\Server;
 use SpinupWp\Endpoints\Site;
+use SpinupWp\Endpoints\SshKey;
 
 /**
  * @property Event $events
  * @property Server $servers
  * @property Site $sites
+ * @property SshKey $sshKeys
  */
 class SpinupWp
 {

--- a/tests/Endpoints/ServerTest.php
+++ b/tests/Endpoints/ServerTest.php
@@ -57,6 +57,20 @@ class ServerTest extends TestCase
         $this->assertEquals('hellfish-media', $server->name);
     }
 
+    public function test_create_custom_request(): void
+    {
+        $this->client->shouldReceive('request')->once()->with('POST', 'servers/custom', [
+            'form_params' => [
+                'hostname' => 'hellfish-media',
+            ],
+        ])->andReturn(
+            new Response(200, [], '{"data": {"name": "hellfish-media"}}')
+        );
+
+        $server = $this->serverEndpoint->createCustom(['hostname' => 'hellfish-media']);
+        $this->assertEquals('hellfish-media', $server->name);
+    }
+
     public function test_delete_request(): void
     {
         $this->client->shouldReceive('request')->once()->with('DELETE', 'servers/1', [

--- a/tests/Endpoints/SshKeyTest.php
+++ b/tests/Endpoints/SshKeyTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Endpoints;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use SpinupWp\Endpoints\Site;
+use SpinupWp\Endpoints\SshKey;
+use SpinupWp\Exceptions\NotFoundException;
+use SpinupWp\Exceptions\RateLimitException;
+use SpinupWp\Exceptions\UnauthorizedException;
+use SpinupWp\Exceptions\ValidationException;
+use SpinupWp\Resources\Event as EventResource;
+use SpinupWp\SpinupWp;
+
+class SshKeyTest extends TestCase
+{
+    public SpinupWp $spinupwp;
+
+    public SshKey $endpoint;
+
+    public Client $client;
+
+    public function setUp(): void
+    {
+        $this->client   = Mockery::mock(Client::class);
+        $this->spinupwp = new SpinupWp('123', $this->client);
+        $this->endpoint = new SshKey($this->spinupwp);
+    }
+
+    public function test_get_request(): void
+    {
+        $this->client->shouldReceive('request')->once()->with('GET', 'ssh-key', [])->andReturn(
+            new Response(200, [], '{"key": "ssh-rsa ..."}')
+        );
+
+        $key = $this->endpoint->get();
+        $this->assertEquals('ssh-rsa ...', $key);
+    }
+}

--- a/tests/SpinupWpTest.php
+++ b/tests/SpinupWpTest.php
@@ -4,6 +4,7 @@ use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
 use SpinupWp\Endpoints\Server;
 use SpinupWp\Endpoints\Site;
+use SpinupWp\Endpoints\SshKey;
 use SpinupWp\SpinupWp;
 
 class SpinupWpTest extends TestCase
@@ -20,5 +21,12 @@ class SpinupWpTest extends TestCase
         $spinupwp = new SpinupWp('123', Mockery::mock(Client::class));
 
         $this->assertInstanceOf(Site::class, $spinupwp->sites);
+    }
+
+    public function test_has_ssh_keys_endpoint(): void
+    {
+        $spinupwp = new SpinupWp('123', Mockery::mock(Client::class));
+
+        $this->assertInstanceOf(SshKey::class, $spinupwp->sshKeys);
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe how and why changes were made. -->
This adds support to our future `/ssh-key` and `/server/custom` endpoints.

## Testing Instructions
<!-- Help others test the pull request as efficiently as possible. -->

1. Install the library
1. Test out the new endpoints